### PR TITLE
non-production: set up codecov in this repo

### DIFF
--- a/.github/workflows/pipeline.yml
+++ b/.github/workflows/pipeline.yml
@@ -6,5 +6,6 @@ on:
 jobs:
   tests:
     uses: Invoca/ruby-test-matrix-workflow/.github/workflows/ruby-test-matrix.yml@main
+    secrets: inherit
     with:
       test-command: 'bundle exec rake'

--- a/Gemfile
+++ b/Gemfile
@@ -9,6 +9,8 @@ group :development do
   gem 'minitest'
   gem 'minitest-reporters'
   gem 'rake'
+  gem 'simplecov', '~> 0.22'
+  gem 'simplecov-lcov', '~> 0.8'
   gem 'test-unit'
   gem 'yard'
 end

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -9,6 +9,7 @@ GEM
     ansi (1.5.0)
     bluecloth (2.2.0)
     builder (3.3.0)
+    docile (1.4.1)
     minitest (5.25.4)
     minitest-reporters (1.7.1)
       ansi
@@ -18,6 +19,13 @@ GEM
     power_assert (2.0.5)
     rake (13.2.1)
     ruby-progressbar (1.13.0)
+    simplecov (0.22.0)
+      docile (~> 1.1)
+      simplecov-html (~> 0.11)
+      simplecov_json_formatter (~> 0.1)
+    simplecov-html (0.13.2)
+    simplecov-lcov (0.9.0)
+    simplecov_json_formatter (0.1.4)
     test-unit (3.6.7)
       power_assert
     yard (0.9.37)
@@ -31,6 +39,8 @@ DEPENDENCIES
   minitest
   minitest-reporters
   rake
+  simplecov (~> 0.22)
+  simplecov-lcov (~> 0.8)
   test-unit
   yard
 

--- a/test/helper.rb
+++ b/test/helper.rb
@@ -1,5 +1,7 @@
 # frozen_string_literal: true
 
+require_relative "simplecov_helper"
+
 require 'minitest/autorun'
 require 'minitest/reporters'
 Minitest::Reporters.use! [

--- a/test/simplecov_helper.rb
+++ b/test/simplecov_helper.rb
@@ -1,0 +1,23 @@
+# frozen_string_literal: true
+
+unless ENV["NO_COVERAGE"] == "true"
+  require "simplecov"
+
+  SimpleCov.start do
+    add_filter "/test/"
+    track_files "lib/**/*.rb"
+
+    if ENV["GITHUB_ACTIONS"]
+      require "simplecov-lcov"
+
+      SimpleCov::Formatter::LcovFormatter.config do |config|
+        config.report_with_single_file = true
+        config.single_report_path = "coverage/lcov.info"
+      end
+
+      formatter SimpleCov::Formatter::LcovFormatter
+    else
+      formatter SimpleCov::Formatter::HTMLFormatter
+    end
+  end
+end


### PR DESCRIPTION
Sets up Codecov coverage reporting:

- Pass secrets: inherit to the shared ruby-test-matrix workflow so CODECOV_TOKEN reaches the Codecov upload step
- Add simplecov and simplecov-lcov (declared in the Gemfile, matching this repo's dev-dependency convention), loaded first from test/helper.rb via test/simplecov_helper.rb; on CI it emits coverage/lcov.info
- Gemfile.lock updated accordingly

Measured local coverage: 94.44% line coverage (7 tests, 0 failures, run with Ruby 3.4.5). Verified coverage/lcov.info is generated when GITHUB_ACTIONS=true.

codecov.yml: not added, since coverage is above 80%.